### PR TITLE
Add vitest tests for getEventStatus

### DIFF
--- a/lib/actions/event/getEventStatus.test.ts
+++ b/lib/actions/event/getEventStatus.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { getEventStatus } from './getEventStatus'
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('getEventStatus', () => {
+  it('returns Upcoming when current date is before start date', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2024-01-01'))
+    const result = getEventStatus(new Date('2024-02-01'), new Date('2024-02-10'))
+    expect(result).toBe('Upcoming')
+  })
+
+  it('returns Ongoing when current date is within the range', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2024-02-05'))
+    const result = getEventStatus(new Date('2024-02-01'), new Date('2024-02-10'))
+    expect(result).toBe('Ongoing')
+  })
+
+  it('returns Finished when current date is after end date', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2024-02-11'))
+    const result = getEventStatus(new Date('2024-02-01'), new Date('2024-02-10'))
+    expect(result).toBe('Finished')
+  })
+})

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "i18nexus pull && cross-env NODE_OPTIONS='--inspect' next dev",
     "build": "i18nexus pull && prisma generate && next build",
     "start": "i18nexus pull &&  next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "vitest"
   },
   "dependencies": {
     "@auth/prisma-adapter": "^2.7.4",
@@ -101,6 +102,8 @@
     "prisma": "^6.2.1",
     "tailwind-scrollbar": "^4.0.1",
     "tailwindcss": "^3.4.1",
-    "typescript": "^5"
+    "typescript": "^5",
+    "vitest": "^1.3.0",
+    "vite": "^5.2.0"
   }
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+  },
+})


### PR DESCRIPTION
## Summary
- set up vitest test runner
- add tests for `getEventStatus`

## Testing
- `yarn install --mode=update-lockfile` *(fails: tunneling socket could not be established)*
- `yarn test` *(fails: package not present in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_683f753f3404832ea574702c4c2fb174