### PR TITLE
Implement rate limiting and bot detection

### DIFF
--- a/app/api/auth/[...nextauth]/route.ts
+++ b/app/api/auth/[...nextauth]/route.ts
@@ -1,3 +1,13 @@
 import { handlers } from '@/auth'
+import { checkBotId } from 'botid/server'
 
-export const { GET, POST } = handlers
+export const GET = handlers.GET
+
+export const POST = async (...args: Parameters<typeof handlers.POST>) => {
+  const verification = await checkBotId()
+  if (verification.isBot) {
+    return Response.json({ error: 'Access denied' }, { status: 403 })
+  }
+
+  return handlers.POST(...args)
+}

--- a/app/api/auth/m/signin/route.ts
+++ b/app/api/auth/m/signin/route.ts
@@ -6,6 +6,7 @@ import bcrypt from 'bcryptjs'
 import { sendVerificationEmail } from '@/lib/actions/email/sendVerificationEmail'
 import { createToken } from '@/lib/actions/token/tokenFunctions'
 import * as jose from 'jose'
+import { checkRateLimit, getClientIp } from '@/lib/security/rateLimit'
 
 interface SignInRequest {
   email: string
@@ -23,6 +24,26 @@ export const POST = async (req: NextRequest) => {
         { message: 'Email or password is not formatted' },
         { status: 400 }
       )
+
+    const clientIp = getClientIp(req.headers.get('x-forwarded-for'))
+    const signinLimit = checkRateLimit({
+      key: `m-signin:${clientIp}:${parsedCredentials.data.email.toLowerCase()}`,
+      limit: 12,
+      windowMs: 2 * 60 * 1000,
+    })
+    if (!signinLimit.allowed) {
+      return NextResponse.json(
+        {
+          message: `Too many sign-in attempts. Try again in ${signinLimit.retryAfterSeconds} seconds.`,
+        },
+        {
+          status: 429,
+          headers: {
+            'Retry-After': String(signinLimit.retryAfterSeconds),
+          },
+        }
+      )
+    }
 
     // Check if the user exists
     const userExists = await prisma.user.findUnique({

--- a/app/api/auth/m/signup/route.ts
+++ b/app/api/auth/m/signup/route.ts
@@ -7,6 +7,7 @@ import { createToken } from '@/lib/actions/token/tokenFunctions'
 import { sendVerificationEmail } from '@/lib/actions/email/sendVerificationEmail'
 import { linkGuestPaymentsToUser } from '@/lib/actions/payment/linkGuestPayments'
 import initTranslation from '@/app/i18n'
+import { checkRateLimit, getClientIp } from '@/lib/security/rateLimit'
 
 interface SignupActionProps {
   firstName: string
@@ -42,6 +43,27 @@ export const POST = async (request: NextRequest) => {
         },
         { status: 400 }
       )
+
+    const clientIp = getClientIp(request.headers.get('x-forwarded-for'))
+    const signupLimit = checkRateLimit({
+      key: `m-signup:${clientIp}:${parsedCredentials.data.email.toLowerCase()}`,
+      limit: 12,
+      windowMs: 2 * 60 * 1000,
+    })
+    if (!signupLimit.allowed) {
+      return NextResponse.json(
+        {
+          message: `Too many sign-up attempts. Try again in ${signupLimit.retryAfterSeconds} seconds.`,
+        },
+        {
+          status: 429,
+          headers: {
+            'Retry-After': String(signupLimit.retryAfterSeconds),
+          },
+        }
+      )
+    }
+
     const existedUser = await prisma.user.findUnique({
       where: {
         email: parsedCredentials.data.email,

--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -1,0 +1,10 @@
+import { initBotId } from 'botid/client/core'
+
+initBotId({
+  protect: [
+    {
+      path: '/api/auth/*',
+      method: 'POST',
+    },
+  ],
+})

--- a/lib/actions/auth/signinAction.ts
+++ b/lib/actions/auth/signinAction.ts
@@ -6,6 +6,8 @@ import { isRedirectError } from "next/dist/client/components/redirect-error";
 import { prisma } from '@/lib/db'
 import initTranslation from '@/app/i18n'
 import { verifyTurnstileToken } from '@/lib/security/verifyTurnstile'
+import { headers } from 'next/headers'
+import { checkRateLimit, getClientIp } from '@/lib/security/rateLimit'
 
 export const signinAction = async (data: {
   email: string
@@ -18,6 +20,22 @@ export const signinAction = async (data: {
   const { t } = await initTranslation(currentLocale, ['signIn-signUp'])
   
   try {
+    const headerStore = await headers()
+    const clientIp = getClientIp(headerStore.get('x-forwarded-for'))
+    const signinKey = `signin:${clientIp}:${data.email.toLowerCase()}`
+    const signinLimit = checkRateLimit({
+      key: signinKey,
+      limit: 12,
+      windowMs: 2 * 60 * 1000,
+    })
+
+    if (!signinLimit.allowed) {
+      return {
+        message: `Too many sign-in attempts. Please try again in ${signinLimit.retryAfterSeconds} seconds.`,
+        success: false,
+      }
+    }
+
     const turnstileResult = await verifyTurnstileToken(data.turnstileToken)
     if (!turnstileResult.ok) {
       return {

--- a/lib/actions/auth/signupAction.ts
+++ b/lib/actions/auth/signupAction.ts
@@ -9,6 +9,8 @@ import { signUpSchema } from '@/lib/zodSchema/signupSchema'
 import { linkGuestPaymentsToUser } from '../payment/linkGuestPayments'
 import initTranslation from '@/app/i18n'
 import { verifyTurnstileToken } from '@/lib/security/verifyTurnstile'
+import { headers } from 'next/headers'
+import { checkRateLimit, getClientIp } from '@/lib/security/rateLimit'
 
 interface signupActionProps {
   firstName: string
@@ -36,6 +38,22 @@ export const signupAction = async (formData: signupActionProps) => {
       locale,
       turnstileToken,
     } = formData
+
+    const headerStore = await headers()
+    const clientIp = getClientIp(headerStore.get('x-forwarded-for'))
+    const signupKey = `signup:${clientIp}:${email.toLowerCase()}`
+    const signupLimit = checkRateLimit({
+      key: signupKey,
+      limit: 12,
+      windowMs: 2 * 60 * 1000,
+    })
+
+    if (!signupLimit.allowed) {
+      return {
+        message: `Too many sign-up attempts. Please try again in ${signupLimit.retryAfterSeconds} seconds.`,
+        success: false,
+      }
+    }
 
     const turnstileResult = await verifyTurnstileToken(turnstileToken)
     if (!turnstileResult.ok) {

--- a/lib/security/rateLimit.ts
+++ b/lib/security/rateLimit.ts
@@ -1,0 +1,52 @@
+type LimitResult = {
+  allowed: boolean
+  retryAfterSeconds: number
+}
+
+type Bucket = {
+  count: number
+  resetAt: number
+}
+
+const store = new Map<string, Bucket>()
+
+const now = () => Date.now()
+
+export const getClientIp = (forwardedForHeader: string | null): string => {
+  if (!forwardedForHeader) return 'unknown'
+
+  const firstIp = forwardedForHeader.split(',')[0]?.trim()
+  return firstIp || 'unknown'
+}
+
+export const checkRateLimit = ({
+  key,
+  limit,
+  windowMs,
+}: {
+  key: string
+  limit: number
+  windowMs: number
+}): LimitResult => {
+  const current = now()
+  const existing = store.get(key)
+
+  if (!existing || existing.resetAt <= current) {
+    store.set(key, { count: 1, resetAt: current + windowMs })
+    return { allowed: true, retryAfterSeconds: 0 }
+  }
+
+  if (existing.count >= limit) {
+    return {
+      allowed: false,
+      retryAfterSeconds: Math.max(
+        1,
+        Math.ceil((existing.resetAt - current) / 1000)
+      ),
+    }
+  }
+
+  existing.count += 1
+  store.set(key, existing)
+  return { allowed: true, retryAfterSeconds: 0 }
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -3,6 +3,11 @@ import { i18nRouter } from 'next-i18n-router'
 import i18nConfig from './i18nConfig'
 import NextAuth from 'next-auth'
 import authConfig from './auth.config'
+import { checkRateLimit, getClientIp } from '@/lib/security/rateLimit'
+
+// app/[locale]/(Home)/posts/page.tsx — listing only (not /posts/[postId] or admin)
+const POSTS_LISTING_PATH =
+  /^\/(?:[a-z]{2}|[a-z]{2}-[A-Z]{2})\/posts\/?$/i
 
 // Patterns for routes that need authentication middleware
 const PROTECTED_PAGE_PATTERNS = [
@@ -53,6 +58,24 @@ export default async function middleware(
   if (staticFiles.includes(pathname)) {
     // Let Next.js handle these as static files
     return NextResponse.next()
+  }
+
+  if (POSTS_LISTING_PATH.test(pathname)) {
+    const clientIp = getClientIp(request.headers.get('x-forwarded-for'))
+    const rate = checkRateLimit({
+      key: `posts-page:${clientIp}`,
+      limit: 100,
+      windowMs: 60000,
+    })
+    if (!rate.allowed) {
+      return new NextResponse('Too many requests. Please try again in 1 minute.', {
+        status: 429,
+        headers: {
+          'Retry-After': String(rate.retryAfterSeconds),
+          'Content-Type': 'text/plain; charset=utf-8',
+        },
+      })
+    }
   }
 
   if (isProtectedRoute(pathname)) {

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,4 +1,5 @@
 import type { NextConfig } from 'next'
+import { withBotId } from 'botid/next/config'
 
 const nextConfig: NextConfig = {
   images: {
@@ -29,4 +30,4 @@ const nextConfig: NextConfig = {
   },
 }
 
-export default nextConfig;
+export default withBotId(nextConfig)

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "add": "^2.0.6",
     "axios": "1.13.5",
     "bcryptjs": "^2.4.3",
+    "botid": "^1.5.11",
     "brace-expansion": "2.0.3",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4791,6 +4791,11 @@ bl@^5.0.0:
     inherits "^2.0.4"
     readable-stream "^3.4.0"
 
+botid@^1.5.11:
+  version "1.5.11"
+  resolved "https://registry.yarnpkg.com/botid/-/botid-1.5.11.tgz#6ad27a45cb96f14c66fc40be813eeff3f6534305"
+  integrity sha512-KOO1A3+/vFVJk5aFoG3sNwiogKFPVR+x4aw4gQ1b2e0XoE+i5xp48/EZn+WqR07jRHeDGwHWQUOtV5WVm7xiww==
+
 brace-expansion@2.0.3, brace-expansion@^2.0.2, brace-expansion@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-2.0.3.tgz#0493338bdd58e319b1039c67cf7ee439892c01d9"


### PR DESCRIPTION
- Added rate limiting for sign-in and sign-up actions to prevent abuse, allowing a maximum of 12 attempts every 2 minutes per IP.
- Integrated bot detection using the 'botid' package in authentication routes to deny access to identified bots.
- Updated middleware to include rate limiting for posts listing requests, returning a 429 status for excessive requests.
- Enhanced the Next.js configuration to include 'botid' for improved bot management.